### PR TITLE
fix: add support for pygments 2.12+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ codereport = 'codereport.cli:main'
 python = "^3.8"
 Jinja2 = "^3.1.1"
 python-slugify = "^6.1.1"
-Pygments = "^2.11.2"
+Pygments = "^2.12.0"
 fs = "^2.4.15"
 
 [tool.poetry.dev-dependencies]

--- a/src/codereport/html.py
+++ b/src/codereport/html.py
@@ -10,7 +10,7 @@ class HtmlFormatter(VanillaHtmlFormatter):
         self._get_line_comment = get_line_comment
         super(HtmlFormatter, self).__init__(*args, **kwargs)
 
-    def wrap(self, source, outfile):
+    def wrap(self, source):
         return self._wrap_div(self._wrap_lines(source))
 
     def _wrap_lines(self, source):

--- a/tests/test_htmlformatter.py
+++ b/tests/test_htmlformatter.py
@@ -10,10 +10,9 @@ def test_wrap():
     html_formatter = HtmlFormatter(get_line_comment=get_line_comment_mock)
 
     source = [(1, "LINE_A"), (1, "LINE_B"), (1, "LINE_C")]
-    outfile = "abc.html"
     
     with patch("codereport.templates.line_tpl", tpl_mock):
-        list(html_formatter.wrap(source, outfile))
+        list(html_formatter.wrap(source))
 
     assert tpl_mock.render.call_count == len(source)
     tpl_mock.render.assert_has_calls([
@@ -23,4 +22,3 @@ def test_wrap():
     ])
 
     assert get_line_comment_mock.call_count == len(source)
-


### PR DESCRIPTION
Hello,
pygments has changed the signature of the wrap method in version 2.12, so it does not include `outfile` anymore. See: https://github.com/pygments/pygments/pull/2101

So if you use newer pygments you will get the following error:
```
Traceback (most recent call last):
  File "/usr/local/bin/codereport", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/lib/python3.11/site-packages/codereport/cli.py", line 24, in main
    report_from_json(os.path.abspath(args.item_file),
  File "/usr/local/lib/python3.11/site-packages/codereport/util.py", line 38, in report_from_json
    cp.render(dest)
  File "/usr/local/lib/python3.11/site-packages/codereport/codereport.py", line 50, in render
    f.write(self._render_code_file(sf))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/codereport/codereport.py", line 77, in _render_code_file
    code = highlight(raw_content, lexer, HtmlFormatter(get_comment))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pygments/__init__.py", line 82, in highlight
    return format(lex(code, lexer), formatter, outfile)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pygments/__init__.py", line 64, in format
    formatter.format(tokens, realoutfile)
  File "/usr/local/lib/python3.11/site-packages/pygments/formatter.py", line 124, in format
    return self.format_unencoded(tokensource, outfile)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pygments/formatters/html.py", line 979, in format_unencoded
    source = self.wrap(source)
             ^^^^^^^^^^^^^^^^^
TypeError: HtmlFormatter.wrap() missing 1 required positional argument: 'outfile'
```

This should help with supporting newer versions of pygments.

Thank you!
